### PR TITLE
Add availability_template to hsbo_differential_ema

### DIFF
--- a/huawei_solar_battery_optimization.yaml
+++ b/huawei_solar_battery_optimization.yaml
@@ -1218,3 +1218,6 @@ sensor:
         value_template: >
           {{ (states('sensor.hsbo_ema_solar_production') | float(0) - 
              states('sensor.hsbo_ema_house_load') | float) | round(2) }}
+        availability_template: >
+          {{ states('sensor.hsbo_ema_solar_production') | is_number and
+             states('sensor.hsbo_ema_house_load') | is_number }}


### PR DESCRIPTION
This will prevent the sensor from failing when the input sensors are unavailable (in unknown state)