### PR TITLE
fix: hsbo_battery_max_capacity to reflect battery capacity

### DIFF
--- a/huawei_solar_battery_optimization_input.yaml
+++ b/huawei_solar_battery_optimization_input.yaml
@@ -11,9 +11,9 @@ input_number:
   # This is a user configured helper to configure your solar plants max battery capacity
   hsbo_battery_max_capacity:
     name: HSBO Battery Max Capacity
-    min: 1
-    max: 100
-    step: 0.1
+    min: 0
+    max: 42
+    step: 1
     unit_of_measurement: kWh
     icon: mdi:battery
 


### PR DESCRIPTION
Change min, step and max to reflect:

1 or 2 BMS with 1 to 3 batteries with either 5 or 7 kWh each